### PR TITLE
name space attributes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,8 +16,8 @@ const bullets = {
 
         // querySelectorAll bug in IOS - can't use 'for of' loop
         for (let i = 0; i < nodes.length; i++) {
-            let component = nodes[i].getAttribute('data-js'),
-                optionsNo = nodes[i].getAttribute('data-options'),
+            let component = nodes[i].getAttribute('data-bullets-js'),
+                optionsNo = nodes[i].getAttribute('data-bullets-options'),
                 options = [];
 
             // get options from data-option-<number>


### PR DESCRIPTION
If we name space the attributes, it won't clash with any other JS library using `data-js` etc.